### PR TITLE
Fix spelling of LICENSE.tex in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ BOOKFILES=./book/book.tex \
 		  ./guide/wrampmon.tex \
 		  ./guide/toolchain.tex \
 		  ./guide/memory-map.tex \
-		  ./LICENCE.tex \
+		  ./LICENSE.tex \
 
 INSNNAME=$(BUILDDIR)/insn.pdf
 INSNFILES=./standalone/insn.tex \


### PR DESCRIPTION
It really does help to spell the filename the same everywhere.